### PR TITLE
Customize waiting timeout with kill_after_timeout option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,8 @@ requires_sudo
     Some of the system commands executed as part of the failover process require either the use of a privileged user or a user with sudo privileges. Set this to *no* when the system user does not need to execute commands using sudo, set to *yes* otherwise
 cluster_interface
     The ethernet interface on the machine that gets the Virtual IP assigned or removed
+kill_after_timeout
+    How many seconds do we want to give the application to close MySQL connections gracefully before killing still active connections on the old master. Set this to *0* to disable waiting and kill all connections immediately.
 
 All the options above can be specified either in the default section or in the host specific sections. Values specified in host specific sections override the values specified in the *default* section.
 
@@ -106,6 +108,7 @@ Let me show you an example configuration file:
     cluster_interface           = eth1
     report_email                = me@ovaistariq.net
     smtp_host                   = localhost
+    kill_after_timeout          = 5
 
     [db10]
     cluster_interface           = eth10

--- a/mha_helper/config_helper.py
+++ b/mha_helper/config_helper.py
@@ -118,7 +118,7 @@ class ConfigHelper(object):
             except ValueError:
                 return False
 
-            return config_value
+            return int(config_value)
 
         if config_key == 'requires_sudo':
             return config_value in ['yes', 'no']

--- a/mha_helper/config_helper.py
+++ b/mha_helper/config_helper.py
@@ -113,12 +113,7 @@ class ConfigHelper(object):
             return ConfigHelper.validate_hostname(config_value)
 
         if config_key == 'kill_after_timeout':
-            try:
-                value = int(config_value)
-            except ValueError:
-                return False
-
-            return int(config_value)
+            return ConfigHelper.validate_integer(config_value)
 
         if config_key == 'requires_sudo':
             return config_value in ['yes', 'no']
@@ -135,6 +130,15 @@ class ConfigHelper(object):
     def validate_email_address(email_address):
         pattern = '^.+\\@(\\[?)[a-zA-Z0-9\\-\\.]+\\.([a-zA-Z]{2,3}|[0-9]{1,3})(\\]?)$'
         return bool(re.match(pattern, email_address))
+
+    @staticmethod
+    def validate_integer(potential_integer):
+            try:
+                value = int(potential_integer)
+            except ValueError:
+                return False
+
+            return True
 
     @staticmethod
     def validate_hostname(hostname):
@@ -183,7 +187,7 @@ class ConfigHelper(object):
         return self._host_config['smtp_host']
 
     def get_kill_after_timeout(self):
-        return self._host_config['kill_after_timeout']
+        return int(self._host_config['kill_after_timeout'])
 
     def get_requires_sudo(self):
         if self._host_config['requires_sudo'] == 'yes':

--- a/mha_helper/config_helper.py
+++ b/mha_helper/config_helper.py
@@ -26,7 +26,7 @@ import ConfigParser
 class ConfigHelper(object):
     MHA_HELPER_CONFIG_DIR = '/etc/mha-helper'
     MHA_HELPER_CONFIG_OPTIONS = ['writer_vip_cidr', 'vip_type', 'report_email', 'smtp_host', 'requires_sudo',
-                                 'cluster_interface']
+                                 'cluster_interface', 'kill_after_timeout']
     VIP_PROVIDER_TYPE_NONE = 'none'
     VIP_PROVIDER_TYPE_METAL = 'metal'
     VIP_PROVIDER_TYPE_AWS = 'aws'
@@ -112,6 +112,14 @@ class ConfigHelper(object):
         if config_key == 'smtp_host':
             return ConfigHelper.validate_hostname(config_value)
 
+        if config_key == 'kill_after_timeout':
+            try:
+                value = int(config_value)
+            except ValueError:
+                return False
+
+            return config_value
+
         if config_key == 'requires_sudo':
             return config_value in ['yes', 'no']
 
@@ -173,6 +181,9 @@ class ConfigHelper(object):
 
     def get_smtp_host(self):
         return self._host_config['smtp_host']
+
+    def get_kill_after_timeout(self):
+        return self._host_config['kill_after_timeout']
 
     def get_requires_sudo(self):
         if self._host_config['requires_sudo'] == 'yes':

--- a/mha_helper/mha_helper.py
+++ b/mha_helper/mha_helper.py
@@ -409,7 +409,7 @@ class MHAHelper(object):
 
     @classmethod
     def __mysql_kill_threads(cls, host, mysql_connection):
-        timeout = 5
+        timeout = cls.orig_master_config.get_kill_after_timeout()
         sleep_interval = 0.1
         start = datetime.datetime.now()
 

--- a/mha_helper/mha_helper.py
+++ b/mha_helper/mha_helper.py
@@ -125,7 +125,7 @@ class MHAHelper(object):
             if not mysql_orig_master.set_read_only() or not mysql_orig_master.is_read_only():
                 return False
 
-            if not self.__mysql_kill_threads(self.orig_master_host, mysql_orig_master):
+            if not self.__mysql_kill_threads(self.orig_master_host, mysql_orig_master, self.orig_master_config.get_kill_after_timeout()):
                 return False
         except Exception as e:
             print("Unexpected error: %s" % str(e))
@@ -408,8 +408,7 @@ class MHAHelper(object):
         return True
 
     @classmethod
-    def __mysql_kill_threads(cls, host, mysql_connection):
-        timeout = cls.orig_master_config.get_kill_after_timeout()
+    def __mysql_kill_threads(cls, host, mysql_connection, timeout):
         sleep_interval = 0.1
         start = datetime.datetime.now()
 


### PR DESCRIPTION
With this feature, you can customize how long you want to wait before killing the connections. This was previously hardcoded to 5 seconds and does not suit everybody's need.