### PR TITLE
Support super read only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,8 @@ vip_type
 - metal : When this is set then traditional baremetal-style VIP management is done using the standard *ip* command
 - aws : When this is set then VIP management is done in a way relevant to AWS *(Currently not implemented)*
 - openstack : When this is set then VIP management is done in a way relevant to OpenStack *(Currently not implemented)*
+super_read_only
+    Certain MySQL flavors (such as Percona Server: https://www.percona.com/doc/percona-server/5.6/management/super_read_only.html) have super_read_only which also disallows users with SUPER privileges to perform any writes. Set this to *yes* to use this feature.
 report_email
     The email address which receives the email notification when a MySQL failover is performed
 smtp_host
@@ -104,6 +106,7 @@ Let me show you an example configuration file:
     vip_type                    = metal
     writer_vip_cidr             = 192.168.10.155/24
     cluster_interface           = eth1
+    super_read_only             = no
     report_email                = me@ovaistariq.net
     smtp_host                   = localhost
 

--- a/mha_helper/config_helper.py
+++ b/mha_helper/config_helper.py
@@ -25,7 +25,7 @@ import ConfigParser
 
 class ConfigHelper(object):
     MHA_HELPER_CONFIG_DIR = '/etc/mha-helper'
-    MHA_HELPER_CONFIG_OPTIONS = ['writer_vip_cidr', 'vip_type', 'report_email', 'smtp_host', 'requires_sudo', 'super_read_only'
+    MHA_HELPER_CONFIG_OPTIONS = ['writer_vip_cidr', 'vip_type', 'report_email', 'smtp_host', 'requires_sudo', 'super_read_only',
                                  'cluster_interface']
     VIP_PROVIDER_TYPE_NONE = 'none'
     VIP_PROVIDER_TYPE_METAL = 'metal'

--- a/mha_helper/config_helper.py
+++ b/mha_helper/config_helper.py
@@ -25,7 +25,7 @@ import ConfigParser
 
 class ConfigHelper(object):
     MHA_HELPER_CONFIG_DIR = '/etc/mha-helper'
-    MHA_HELPER_CONFIG_OPTIONS = ['writer_vip_cidr', 'vip_type', 'report_email', 'smtp_host', 'requires_sudo',
+    MHA_HELPER_CONFIG_OPTIONS = ['writer_vip_cidr', 'vip_type', 'report_email', 'smtp_host', 'requires_sudo', 'super_read_only'
                                  'cluster_interface']
     VIP_PROVIDER_TYPE_NONE = 'none'
     VIP_PROVIDER_TYPE_METAL = 'metal'
@@ -118,6 +118,9 @@ class ConfigHelper(object):
         if config_key == 'cluster_interface':
             return config_value is not None and len(config_value) > 0
 
+        if config_key == 'super_read_only':
+            return config_value in ['yes', 'no']
+
     @staticmethod
     def validate_ip_address(ip_address):
         pattern = '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(/([0-9]|[1-2][0-9]|3[0-2]))$'
@@ -182,3 +185,7 @@ class ConfigHelper(object):
 
     def get_cluster_interface(self):
         return self._host_config['cluster_interface']
+
+    def get_super_read_only(self):
+        return self._host_config['super_read_only']
+

--- a/mha_helper/mha_helper.py
+++ b/mha_helper/mha_helper.py
@@ -121,9 +121,15 @@ class MHAHelper(object):
                                                    self.FAILOVER_TYPE_ONLINE):
                     return False
 
-            print("Setting read_only to '1' on the original master '%s'" % self.orig_master_host)
-            if not mysql_orig_master.set_read_only() or not mysql_orig_master.is_read_only():
-                return False
+            if self.orig_master_config.get_super_read_only() == 'no':
+                print("Setting read_only to '1' on the original master '%s'" % self.orig_master_host)
+                if not mysql_orig_master.set_read_only() or not mysql_orig_master.is_read_only():
+                    return False
+            else:
+                print("Setting super_read_only to '1' on the original master '%s'" % self.orig_master_host)
+                if not mysql_orig_master.set_super_read_only() or not mysql_orig_master.is_super_read_only():
+                    return False
+
 
             if not self.__mysql_kill_threads(self.orig_master_host, mysql_orig_master):
                 return False
@@ -243,9 +249,15 @@ class MHAHelper(object):
             if not mysql_new_master.connect():
                 return False
 
-            print("Setting read_only to '0' on the new master '%s'" % self.new_master_host)
-            if not mysql_new_master.unset_read_only() or mysql_new_master.is_read_only():
-                return False
+            if self.new_master_config.get_super_read_only() == 'no':
+                print("Setting read_only to '0' on the new master '%s'" % self.new_master_host)
+                if not mysql_new_master.unset_read_only() or mysql_new_master.is_read_only():
+                    return False
+            else:
+                print("Setting super_read_only to '0' on the new master '%s'" % self.new_master_host)
+                if not mysql_new_master.unset_super_read_only() or mysql_new_master.is_super_read_only():
+                    return False
+
 
             if self.new_master_config.get_manage_vip():
                 vip_type = self.new_master_config.get_vip_type()
@@ -328,11 +340,18 @@ class MHAHelper(object):
                 print("Failed to connect to mysql on the original master '%s'" % self.orig_master_host)
                 return False
 
-            if not mysql_orig_master.unset_read_only() or mysql_orig_master.is_read_only():
-                print("Failed to reset read_only to '0' on the original master '%s'" % self.orig_master_host)
-                return False
+            if self.orig_master_conf.get_super_read_only() == 'no':
+                if not mysql_orig_master.unset_read_only() or mysql_orig_master.is_read_only():
+                    print("Failed to reset read_only to '0' on the original master '%s'" % self.orig_master_host)
+                    return False
 
-            print("Set read_only back to '0' on the original master '%s'" % self.orig_master_host)
+                print("Set read_only back to '0' on the original master '%s'" % self.orig_master_host)
+            else:
+                if not mysql_orig_master.unset_super_read_only() or mysql_orig_master.is_super_read_only():
+                    print("Failed to reset super_read_only to '0' on the original master '%s'" % self.orig_master_host)
+                    return False
+
+                print("Set super_read_only back to '0' on the original master '%s'" % self.orig_master_host)
 
             if self.orig_master_config.get_manage_vip():
                 vip_type = self.orig_master_config.get_vip_type()

--- a/mha_helper/mysql_helper.py
+++ b/mha_helper/mysql_helper.py
@@ -108,6 +108,41 @@ class MySQLHelper(object):
 
         return False
 
+    def set_super_read_only(self):
+        cursor = self._connection.cursor()
+        try:
+            cursor.execute("SET GLOBAL super_read_only = 1")
+        except pymysql.Error as e:
+            print("Error %d: %s" % (e.args[0], e.args[1]))
+            return False
+        finally:
+            cursor.close()
+
+        return True
+
+    def unset_super_read_only(self):
+        cursor = self._connection.cursor()
+        try:
+            cursor.execute("SET GLOBAL super_read_only = 0")
+        except pymysql.Error as e:
+            print("Error %d: %s" % (e.args[0], e.args[1]))
+            return False
+        finally:
+            cursor.close()
+
+        return True
+
+    def is_super_read_only(self):
+        cursor = self._connection.cursor()
+        cursor.execute("SELECT @@super_read_only")
+        row = cursor.fetchone()
+        cursor.close()
+
+        if row[0] == 1:
+            return True
+
+        return False
+
     def disable_log_bin(self):
         cursor = self._connection.cursor()
         try:


### PR DESCRIPTION
when using GTID, I think it's very important to not have SUPER users break replication by writing on slaves, even not users (as it creates GTID event). percona server has https://www.percona.com/doc/percona-server/5.6/management/super_read_only.html.

That's why I added `super_read_only` support to mha-helper