### PR TITLE
When shlex.split() is passed None it then it reads from stdin.

### DIFF
--- a/mha_helper/ssh_helper.py
+++ b/mha_helper/ssh_helper.py
@@ -63,7 +63,7 @@ class SSHHelper(object):
 
         if self._ssh_options is not None:
             (options, args) = parser.parse_args(shlex.split(self._ssh_options))
-        else
+        else:
             (options, args) = parser.parse_args()
 
         if options.key_file_path is not None:

--- a/mha_helper/ssh_helper.py
+++ b/mha_helper/ssh_helper.py
@@ -61,7 +61,10 @@ class SSHHelper(object):
         parser.add_option('-o', '--additional_options', action='append', type='string')
         parser.add_option('-i', '--key_file_path', type='string')
 
-        (options, args) = parser.parse_args(shlex.split(self._ssh_options))
+        if self._ssh_options is not None:
+            (options, args) = parser.parse_args(shlex.split(self._ssh_options))
+        else
+            (options, args) = parser.parse_args()
 
         if options.key_file_path is not None:
             ssh_options['key_filename'] = options.key_file_path


### PR DESCRIPTION
According the [shlex.split() documentation](https://docs.python.org/2/library/shlex.html), when passed `None` shlex.split() reading from stdin for args and passes the program until input is given. This is not desired.

Added code to check for `None`, and skip the call to shlex.split().